### PR TITLE
fix: padding in swipe button when have large text

### DIFF
--- a/src/components/SwipeButton/styled.ts
+++ b/src/components/SwipeButton/styled.ts
@@ -15,7 +15,7 @@ export const Container = attachThemeAttrs(styled.View)<{ isLoading: boolean }>`
     ${props =>
         !props.isLoading &&
         `
-        padding: 14px 62px;
+        padding: 0px 62px;
     `}
 `;
 

--- a/src/components/SwipeButton/styled.ts
+++ b/src/components/SwipeButton/styled.ts
@@ -15,7 +15,7 @@ export const Container = attachThemeAttrs(styled.View)<{ isLoading: boolean }>`
     ${props =>
         !props.isLoading &&
         `
-        padding: 0px 62px;
+        padding: 0px 10px 0px 65px;
     `}
 `;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: padding in swipe button when have large text

## Changes proposed in this PR:
-

@nexxtway/react-rainbow
