### PR TITLE
fix: dark mode on placeholder input

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -6,6 +6,7 @@ import useReactHookForm from '../../hooks/useReactHookForm';
 import StyledInput from './styled/input';
 import { Label, Error, Icon } from './styled';
 import { IconPosition } from '../types';
+import useTheme from '../../hooks/useTheme';
 
 const inputTypePropsMap = {
     text: {},
@@ -70,6 +71,7 @@ const Input = React.forwardRef<any, Props>((props, ref) => {
     const inputProps = inputTypePropsMap[type] || inputTypePropsMap.text;
 
     const [isFocused, setFocusState] = useState(false);
+    const theme = useTheme();
 
     const handleFocus = () => {
         setFocusState(true);
@@ -103,6 +105,7 @@ const Input = React.forwardRef<any, Props>((props, ref) => {
                     disabled={disabled}
                     hasIcon={!!icon}
                     iconPosition={iconPosition}
+                    placeholderTextColor={theme.rainbow.palette.text.header}
                     ref={ref}
                 />
                 <RenderIf isTrue={!!icon}>

--- a/src/components/InputPhone/index.tsx
+++ b/src/components/InputPhone/index.tsx
@@ -16,6 +16,7 @@ import {
 import CountryPickerModal, { CountryType } from './countyPickerModal';
 import getCountryFromValue from './helpers/getCountryFromValue';
 import { BaseProps } from '../types';
+import useTheme from '../../hooks/useTheme';
 
 interface Value {
     countryCode?: string;
@@ -65,6 +66,7 @@ const InputPhone = React.forwardRef<any, Props>((props, ref) => {
     const [selectedCountry, setCountry] = useState<CountryType>(
         () => getCountryFromValue(isoCode) || defaultCountry,
     );
+    const theme = useTheme();
 
     const selectCountry = (country: CountryType) => {
         setCountry(country);
@@ -111,6 +113,7 @@ const InputPhone = React.forwardRef<any, Props>((props, ref) => {
                     disabled={disabled}
                     keyboardType="number-pad"
                     autoFocus={autoFocus}
+                    placeholderTextColor={theme.rainbow.palette.text.header}
                     ref={ref}
                 />
                 <LeftElement>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -72,6 +72,7 @@ const Select = (props: Props) => {
         placeholder,
         disabled,
         options,
+        textInputProps: textInputPropsProp,
         ...rest
     } = useReactHookForm(props);
     const {
@@ -96,6 +97,7 @@ const Select = (props: Props) => {
     const selectPlaceholder = placeholder ? { label: placeholder, value: null } : {};
     const textInputProps = {
         placeholderTextColor: palette.text.header,
+        ...textInputPropsProp,
     };
 
     return (

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -94,6 +94,9 @@ const Select = (props: Props) => {
         };
     }, [disabled, error, palette]);
     const selectPlaceholder = placeholder ? { label: placeholder, value: null } : {};
+    const textInputProps = {
+        placeholderTextColor: palette.text.header,
+    };
 
     return (
         <View style={style}>
@@ -112,6 +115,7 @@ const Select = (props: Props) => {
                     Icon={() => <ArrowIcon disabled={disabled} error={error} />}
                     style={styles}
                     useNativeAndroidPickerStyle={false}
+                    textInputProps={textInputProps}
                 />
             </View>
             <RenderIf isTrue={!!error}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! 🌈 -->

<!-- Please begin the title with `type: [ imperative message ]` -->

fix: dark mode on placeholder input
fix: dark mode on placeholder select

## Changes proposed in this PR:
-

@nexxtway/react-rainbow
